### PR TITLE
Add a per-device setting (with global default) which provides the required inrush current to start the haptic for low tx values

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -40,7 +40,6 @@ devices:
   # Device 2
   - ip: 192.168.1.70
     proximity_parameter: proximity_02
-    min_speed: 5
     max_speed: 40
     speed_scale: 90
     max_speed_parameter: max_speed_02
@@ -56,15 +55,10 @@ devices:
     max_speed: 60
     speed_scale: 100
     max_speed_parameter: max_speed_03
-    use_velocity_control: false
-    outer_proximity: 0.1
-    inner_proximity: 0.6
-    velocity_scalar: 25
 
   # Device 4
   - ip: 192.168.1.73
     proximity_parameter: proximity_04
-    min_speed: 5
     max_speed: 100
     speed_scale: 100
     max_speed_parameter: max_speed_04

--- a/config.yml
+++ b/config.yml
@@ -15,7 +15,7 @@ setup:
   default_max_speed: 25
 
   # The minimum initial speed used when the haptic motor is started (Recommended: 5-15)
-  default_start_tx: 10
+  default_start_tx: 20
 
   # Maximum Speed Parameter
   default_max_speed_parameter: max_speed

--- a/config.yml
+++ b/config.yml
@@ -44,7 +44,7 @@ devices:
   - ip: 192.168.1.70
     proximity_parameter: proximity_02
     max_speed: 40
-    start_tx: 20
+    start_tx: 30
     speed_scale: 90
     max_speed_parameter: max_speed_02
     use_velocity_control: true

--- a/config.yml
+++ b/config.yml
@@ -44,7 +44,7 @@ devices:
   - ip: 192.168.1.70
     proximity_parameter: proximity_02
     max_speed: 40
-    start_tx: 15
+    start_tx: 20
     speed_scale: 90
     max_speed_parameter: max_speed_02
     use_velocity_control: true

--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,9 @@ setup:
   # Maximum Speed of Haptic Motor (Recommended: 5-25)
   default_max_speed: 25
 
+  # The minimum initial speed used when the haptic motor is started (Recommended: 5-15)
+  default_start_tx: 10
+
   # Maximum Speed Parameter
   default_max_speed_parameter: max_speed
 
@@ -41,6 +44,7 @@ devices:
   - ip: 192.168.1.70
     proximity_parameter: proximity_02
     max_speed: 40
+    start_tx: 15
     speed_scale: 90
     max_speed_parameter: max_speed_02
     use_velocity_control: true

--- a/giggletech-router/src/config.rs
+++ b/giggletech-router/src/config.rs
@@ -123,14 +123,18 @@ pub(crate) fn load_config() -> (GlobalConfig, Vec<DeviceConfig>) {
     banner_txt();
     println!("\n");
     println!(" Device Maps");
+    println!("");
     for (i, device) in devices.iter().enumerate() {
         println!("  Device {i}");
         println!("   {} => {}", device.proximity_parameter.trim_start_matches("/avatar/parameters/"), device.device_uri);
         println!("   Vibration Configuration");
-        println!("    Min Speed: {:?}%", device.min_speed * 100.0);
-        println!("    Max Speed: {:?}%", device.max_speed * 100.0);
-        println!("    Scale Factor: {:?}%", device.speed_scale * 100.0);
+        println!("    Startup TX Speed: {:.0}%", device.start_tx);
+        println!("    Min Speed: {:.0}%", device.min_speed * 100.0);
+        println!("    Max Speed: {:.0}%", device.max_speed * 100.0);
+        println!("    Scale Factor: {:.0}%", device.speed_scale * 100.0);
         println!("    Advanced Mode: {}", device.use_velocity_control);
+        println!("");
+
     }
 
     println!("\n Listening for OSC on port: {}", global_config.port_rx);

--- a/giggletech-router/src/config.rs
+++ b/giggletech-router/src/config.rs
@@ -29,6 +29,7 @@ pub(crate) struct DeviceConfig {
     pub device_uri: Arc<String>,
     pub min_speed: f32,
     pub max_speed: f32,
+    pub start_tx: i32,
     pub speed_scale: f32,
     pub proximity_parameter: Arc<String>,
     pub max_speed_parameter: Arc<String>,
@@ -44,6 +45,7 @@ pub(crate) struct GlobalConfig {
     pub default_min_speed: f32,
     pub default_max_speed: f32,
     pub default_speed_scale: f32,
+    pub default_start_tx: i32,
     pub default_max_speed_parameter: Arc<String>,
     pub minimum_max_speed: f32,
     pub timeout: u64,
@@ -152,6 +154,8 @@ fn parse_global_config(setup: YamlHashWrapper) -> GlobalConfig {
     let default_max_speed = setup.get_f64("default_max_speed").unwrap() as f32 / 100.0;
     let default_max_speed = default_max_speed.max(default_min_speed).max(MAX_SPEED_LOW_LIMIT_CONST);
 
+    let default_start_tx = setup.get_i64("default_start_tx").unwrap() as i32;
+
     let default_max_speed_parameter = setup.get_str("default_max_speed_parameter").unwrap_or("max_speed".to_string());
     let default_max_speed_parameter = Arc::new(format!("/avatar/parameters/{}", default_max_speed_parameter));
 
@@ -169,6 +173,7 @@ fn parse_global_config(setup: YamlHashWrapper) -> GlobalConfig {
         default_min_speed,
         default_max_speed,
         default_max_speed_parameter,
+        default_start_tx,
         minimum_max_speed: MAX_SPEED_LOW_LIMIT_CONST,
         default_speed_scale,
         timeout,
@@ -186,6 +191,7 @@ fn parse_device_config(device_data: YamlHashWrapper, global_config: &GlobalConfi
     let min_speed = device_data.get_f64("min_speed").map(|x| x as f32 / 100.0).unwrap_or(global_config.default_min_speed);
     assert!(min_speed >= 0.0);
     let max_speed = device_data.get_f64("max_speed").map(|x| (x as f32 / 100.0).max(min_speed).max(global_config.minimum_max_speed)).unwrap_or(global_config.default_max_speed);
+    let start_tx = device_data.get_i64("start_tx").map(|x| x as i32).unwrap_or(global_config.default_start_tx);
     let speed_scale = device_data.get_f64("speed_scale").map(|x| x as f32 / 100.0).unwrap_or(global_config.default_speed_scale);
     let max_speed_parameter = device_data.get_str("max_speed_parameter").map(|x| Arc::new(format!("/avatar/parameters/{}", x))).unwrap_or(global_config.default_max_speed_parameter.clone());
     let use_velocity_control = device_data.get_bool("use_velocity_control").unwrap_or(global_config.default_use_velocity_control);
@@ -198,6 +204,7 @@ fn parse_device_config(device_data: YamlHashWrapper, global_config: &GlobalConfi
         proximity_parameter,
         min_speed,
         max_speed,
+        start_tx,
         speed_scale,
         max_speed_parameter,
         use_velocity_control,

--- a/giggletech-router/src/data_processing.rs
+++ b/giggletech-router/src/data_processing.rs
@@ -26,9 +26,15 @@ pub fn print_speed_limit(headpat_max_rx: f32) {
 // Pat Processor
 const MOTOR_SPEED_SCALE: f32 = 0.66; // Overvolt   Here, OEM config 0.66 going higher than this value will reduce your vibrator motor life
 
-pub fn process_pat(proximity_signal: f32, device: &DeviceConfig) -> i32 {
+pub fn process_pat(proximity_signal: f32, device: &DeviceConfig, prev_signal: f32) -> i32 {
     let graph_str = proximity_graph(proximity_signal);
     let headpat_tx = (((device.max_speed - device.min_speed) * proximity_signal + device.min_speed) * MOTOR_SPEED_SCALE * device.speed_scale * 255.0).round() as i32;
+    let headpat_tx = if prev_signal == 0.0 && proximity_signal > 0.0 && headpat_tx < device.start_tx {
+        device.start_tx
+    } else {
+        headpat_tx
+    };
+
     let proximity_signal = format!("{:.2}", proximity_signal);
     eprintln!("{} Prox: {:5} Motor Tx: {:3} |{:11}|", device.proximity_parameter.trim_start_matches("/avatar/parameters/") , proximity_signal, headpat_tx, graph_str);
 

--- a/giggletech-router/src/handle_proximity_parameter.rs
+++ b/giggletech-router/src/handle_proximity_parameter.rs
@@ -47,7 +47,7 @@ pub(crate) async fn handle_proximity_parameter(
     } else {
         if !device.use_velocity_control {
             giggletech_osc::send_data(&device_ip,
-                data_processing::process_pat(value, &device)).await?;
+                data_processing::process_pat(value, &device, last_val)).await?;
         } else {
             let delta_t = match last_signal_time {
                 None => Duration::new(0, 0),
@@ -57,8 +57,6 @@ pub(crate) async fn handle_proximity_parameter(
             giggletech_osc::send_data(&device_ip,
                 data_processing::process_pat_advanced(value, last_val, delta_t, &device)).await?;
         }
-
-
     }
     Ok(())
 }


### PR DESCRIPTION
Since the haptic motor requires an amount of current to get started, starting with low tx values will not start the haptic motor. This PR adds a setting which which allows an initial tx value to be defined so that any tx value less than it is set to this value when sending the first value to the haptic after a zero-value.

The old behavior can still be used by setting the initial tx value to 0 (not sure why you'd want to do that though).

An default initial tx value of 20 was chosen experimentally and appears to work fine for both the puck and spark without feeling any different.

This change only affects the non-velocity mode since the velocity mode tends to have high enough values for tx where this isn't an issue.